### PR TITLE
minor corrections to the requirements specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,16 @@
 
 clone this repository and navigate into the project directory
 
+The following has been tested with Python version 3.7.4.
+
 ### Install Dependencies
 - `pip install -r requirements_compact.txt`
 - `pip install Cython`
 - `pip install pot` or `conda install -c conda-forge pot`
 
 #### Testing if all dependencies met and the code could run properly
-- make test
-- make test_label
+- `make test`
+- `make test_label`
 - The above command will use minimal epochs to test if the whole process below works
 - The above command will generate results with different folder names so will not affect the major
   result

--- a/requirements_compact.txt
+++ b/requirements_compact.txt
@@ -17,7 +17,7 @@ pbr==5.1.3
 protobuf==3.7.1
 pyparsing==2.4.0
 python-dateutil==2.8.0
-pillow
+pillow==6.1
 scipy==1.2.1
 six==1.12.0
 tensorboard==1.14.0  # cuda9
@@ -27,7 +27,7 @@ tensorflow-estimator==1.14.0
 termcolor==1.1.0
 tornado
 Werkzeug==0.15.2
-sklearn==0.21.3  # Kfold, vgmm
+scikit-learn==0.21.3  # Kfold, vgmm
 pandas
 torch==1.0.1.post2  # dataset class
 torchvision==0.2.2


### PR DESCRIPTION
- pillow version 7 gives "ImportError: cannot import name 'PILLOW_VERSION' from 'PIL'" when running `make test`". So, I fixed it to `==6.1` which works fine.
- 'pip install sklearn' didn't work for me, so corrected it to `scikit-learn`.
- installing requirements failed with python 3.8 for me. So, I specified version 3.7.4 in the README.